### PR TITLE
refactor: externalize supabase config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
+      - name: Ensure no Supabase tokens committed
+        run: |
+          if rg "eyJhbGci" -n --glob '!**/__tests__/**' --glob '!**/*.test.*' --glob '!**/*.spec.*'; then
+            echo "Supabase tokens detected in repository"
+            exit 1
+          fi
+
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ El proyecto utiliza Supabase para el manejo de secrets, **no requiere archivo `.
 
 | Variable | Descripción | Ejemplo |
 |----------|-------------|---------|
-| `SUPABASE_URL` | URL del proyecto Supabase | `https://xxxxx.supabase.co` |
-| `SUPABASE_ANON_KEY` | Clave pública de Supabase para autenticación | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` |
-| `SUPABASE_SERVICE_ROLE_KEY` | Clave de servicio para operaciones administrativas | `eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...` |
+| `SUPABASE_URL` | URL del proyecto Supabase | `<SUPABASE_URL>` |
+| `SUPABASE_ANON_KEY` | Clave pública de Supabase para autenticación | `<SUPABASE_KEY>` |
+| `SUPABASE_SERVICE_ROLE_KEY` | Clave de servicio para operaciones administrativas | `<SUPABASE_KEY>` |
 | `SUPABASE_DB_URL` | URL directa de la base de datos PostgreSQL | `postgresql://postgres:password@db.xxx.supabase.co:5432/postgres` |
 | `OPENAI_API_KEY` | API key para funcionalidades de IA | `sk-proj-xxxxx` |
 | `RESEND_API_KEY` | API key para envío de emails | `re_xxxxx` |
@@ -45,8 +45,8 @@ npm install
 > Instala todas las dependencias del proyecto incluyendo React, TypeScript, Tailwind CSS y las librerías de UI.
 
 ### 3. Configurar Supabase (requerido)
-- El proyecto está conectado al proyecto Supabase: `hmmaubkxfewzlypywqff`
-- Las credenciales están configuradas en `src/lib/config.ts`
+- Define `SUPABASE_URL` y `SUPABASE_ANON_KEY` como variables de entorno
+  o en `src/lib/config.ts` (sin incluir valores reales en el repositorio).
 - No se requiere configuración adicional para desarrollo
 
 ### 4. Ejecutar migraciones de base de datos (si es necesario)

--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -21,17 +21,17 @@ TUPÁ Hub is deployed using Lovable's hosting platform with Supabase as the back
 
 **Required in Supabase Dashboard > Settings > API:**
 ```
-Project URL: https://your-project-id.supabase.co
-Anon Key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-Service Role Key: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9... (backend only)
+Project URL: <SUPABASE_URL>
+Anon Key: <SUPABASE_KEY>
+Service Role Key: <SUPABASE_KEY> (backend only)
 ```
 
 **Required Supabase Secrets** (for Edge Functions):
 ```bash
 # Core Supabase
-SUPABASE_URL=https://your-project-id.supabase.co
-SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
-SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...
+SUPABASE_URL=<SUPABASE_URL>
+SUPABASE_ANON_KEY=<SUPABASE_KEY>
+SUPABASE_SERVICE_ROLE_KEY=<SUPABASE_KEY>
 SUPABASE_DB_URL=postgresql://postgres:[PASSWORD]@db.your-project-id.supabase.co:5432/postgres
 
 # External Services

--- a/load-test.yml
+++ b/load-test.yml
@@ -31,9 +31,9 @@ scenarios:
       # Simular refresh token endpoint
       - post:
           url: "/functions/v1/refresh-token-test"
-          headers:
-            Authorization: "Bearer {{ $randomString() }}"
-            apikey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhtbWF1Ymt4ZmV3emx5cHl3cWZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI4ODcwNjAsImV4cCI6MjA2ODQ2MzA2MH0.SahVxttR7FcNfYR7hEL4N-ouOrhydtvPVTkKs_o5jCg"
+            headers:
+              Authorization: "Bearer {{ $randomString() }}"
+              apikey: "<SUPABASE_KEY>"
           json:
             refresh_token: "mock_refresh_token_{{ $randomString() }}"
             user_id: "{{ $randomString() }}"
@@ -53,7 +53,7 @@ scenarios:
     flow:
       - get:
           url: "/functions/v1/notify-team"
-          headers:
-            apikey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhtbWF1Ymt4ZmV3emx5cHl3cWZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI4ODcwNjAsImV4cCI6MjA2ODQ2MzA2MH0.SahVxttR7FcNfYR7hEL4N-ouOrhydtvPVTkKs_o5jCg"
+            headers:
+              apikey: "<SUPABASE_KEY>"
           expect:
             - statusCode: [200, 405] # GET might not be allowed on this endpoint

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,8 +1,8 @@
 // Centralized configuration for the application
 export const config = {
   supabase: {
-    url: "https://hmmaubkxfewzlypywqff.supabase.co",
-    anonKey: "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhtbWF1Ymt4ZmV3emx5cHl3cWZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI4ODcwNjAsImV4cCI6MjA2ODQ2MzA2MH0.SahVxttR7FcNfYR7hEL4N-ouOrhydtvPVTkKs_o5jCg"
+    url: import.meta.env.SUPABASE_URL,
+    anonKey: import.meta.env.SUPABASE_ANON_KEY
   },
   development: {
     enableTestingMode: import.meta.env.DEV

--- a/supabase/migrations/20250726012037-834a2c82-5cb2-4539-af06-b800bc067f83.sql
+++ b/supabase/migrations/20250726012037-834a2c82-5cb2-4539-af06-b800bc067f83.sql
@@ -9,8 +9,8 @@ SELECT cron.schedule(
   $$
   SELECT
     net.http_post(
-        url:='https://hmmaubkxfewzlypywqff.supabase.co/functions/v1/weekly-giveaway-selection',
-        headers:='{"Content-Type": "application/json", "Authorization": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImhtbWF1Ymt4ZmV3emx5cHl3cWZmIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTI4ODcwNjAsImV4cCI6MjA2ODQ2MzA2MH0.SahVxttR7FcNfYR7hEL4N-ouOrhydtvPVTkKs_o5jCg"}'::jsonb,
+        url:='<SUPABASE_URL>/functions/v1/weekly-giveaway-selection',
+        headers:='{"Content-Type": "application/json", "Authorization": "Bearer <SUPABASE_KEY>"}'::jsonb,
         body:='{"automated": true}'::jsonb
     ) as request_id;
   $$


### PR DESCRIPTION
## Summary
- load Supabase credentials from `import.meta.env`
- document environment placeholders for Supabase
- fail CI if JWT-like tokens are committed

## Testing
- `rg eyJhbGci -n`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: Could not resolve dependency: react-day-picker@8.10.1)*

------
https://chatgpt.com/codex/tasks/task_e_6896aabe3070832d84b088a57284dd9b