### PR TITLE
refactor: centralize roles enum and type guard

### DIFF
--- a/src/__tests__/utils/roles.test.ts
+++ b/src/__tests__/utils/roles.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { Roles, isRole } from '@/constants/roles';
+
+describe('Roles constant', () => {
+  it('should contain expected role values', () => {
+    expect(Roles.ADMIN).toBe('admin');
+    expect(Roles.OWNER).toBe('owner');
+    expect(Roles.MANAGER).toBe('manager');
+    expect(Roles.BARISTA).toBe('barista');
+    expect(Roles.USER).toBe('user');
+  });
+});
+
+describe('isRole type guard', () => {
+  it('returns true for valid roles', () => {
+    Object.values(Roles).forEach(role => {
+      expect(isRole(role)).toBe(true);
+    });
+  });
+
+  it('returns false for invalid roles', () => {
+    expect(isRole('invalid')).toBe(false);
+    expect(isRole(null)).toBe(false);
+  });
+});

--- a/src/components/AddBaristaModal.tsx
+++ b/src/components/AddBaristaModal.tsx
@@ -13,6 +13,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { useToast } from '@/hooks/use-toast';
 import { supabase } from '@/integrations/supabase/client';
 import { UserPlus, Mail, User, Building, Coffee } from 'lucide-react';
+import { Roles, isRole } from '@/constants/roles';
 
 interface AddBaristaModalProps {
   open: boolean;
@@ -30,7 +31,7 @@ export const AddBaristaModal: React.FC<AddBaristaModalProps> = ({
   const [formData, setFormData] = useState({
     fullName: '',
     email: '',
-    role: 'barista',
+    role: Roles.BARISTA,
     phone: ''
   });
 
@@ -74,7 +75,7 @@ export const AddBaristaModal: React.FC<AddBaristaModalProps> = ({
         }
 
         // Reset form and close modal
-        setFormData({ fullName: '', email: '', role: 'barista', phone: '' });
+        setFormData({ fullName: '', email: '', role: Roles.BARISTA, phone: '' });
         onOpenChange(false);
         onSuccess?.();
       } else {
@@ -151,12 +152,12 @@ export const AddBaristaModal: React.FC<AddBaristaModalProps> = ({
               <Coffee className="h-4 w-4" />
               Rol
             </Label>
-            <Select value={formData.role} onValueChange={(value) => setFormData({ ...formData, role: value })}>
+            <Select value={formData.role} onValueChange={(value) => setFormData({ ...formData, role: isRole(value) ? value : formData.role })}>
               <SelectTrigger>
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="barista">Barista</SelectItem>
+                <SelectItem value={Roles.BARISTA}>Barista</SelectItem>
                 <SelectItem value="barista_junior">Barista Junior</SelectItem>
                 <SelectItem value="barista_senior">Barista Senior</SelectItem>
                 <SelectItem value="encargado">Encargado</SelectItem>

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { ADMIN_NAVIGATION, getNavItemsForRole } from "@/constants/adminNavigation";
 import { useRequireAdmin } from "@/hooks/useOptimizedAuth";
+import { Roles } from "@/constants/roles";
 import { 
   Collapsible,
   CollapsibleContent,
@@ -18,7 +19,7 @@ export function AdminSidebar() {
   const { isAdmin } = useRequireAdmin();
   
   // Mock user role - in real app this would come from auth context
-  const userRole = isAdmin ? 'admin' : 'user';
+  const userRole = isAdmin ? Roles.ADMIN : Roles.USER;
   const navGroups = getNavItemsForRole(userRole);
 
   const toggleGroup = (groupKey: string) => {

--- a/src/components/dashboards/RoleDashboard.tsx
+++ b/src/components/dashboards/RoleDashboard.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
 import { useSmartNavigation } from '@/utils/routing/redirects';
+import { Roles } from '@/constants/roles';
 
 interface DashboardWidget {
   id: string;
@@ -102,7 +103,7 @@ export function RoleDashboard({ userRole, isAdmin, activeLocation, activeCafe }:
     }
 
     switch (userRole?.toLowerCase()) {
-      case 'owner':
+      case Roles.OWNER:
         return [
           {
             id: 'revenue',
@@ -180,7 +181,7 @@ export function RoleDashboard({ userRole, isAdmin, activeLocation, activeCafe }:
           }
         ];
 
-      case 'manager':
+      case Roles.MANAGER:
         return [
           {
             id: 'operations',
@@ -253,7 +254,7 @@ export function RoleDashboard({ userRole, isAdmin, activeLocation, activeCafe }:
           }
         ];
 
-      case 'barista':
+      case Roles.BARISTA:
         return [
           {
             id: 'daily-tasks',

--- a/src/components/debug/AuthDebugPanel.tsx
+++ b/src/components/debug/AuthDebugPanel.tsx
@@ -3,6 +3,7 @@ import { useOptimizedAuth } from '@/contexts/OptimizedAuthProvider';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Loader2, ShieldCheck, User, Settings } from 'lucide-react';
+import { Roles } from '@/constants/roles';
 
 const AuthDebugPanel: React.FC = () => {
   const { user, session, userRole, loading } = useOptimizedAuth();
@@ -56,9 +57,9 @@ const AuthDebugPanel: React.FC = () => {
           <Badge 
             variant={userRole ? "default" : "secondary"}
             className={
-              userRole === 'admin' ? 'bg-red-600' :
+              userRole === Roles.ADMIN ? 'bg-red-600' :
               userRole === 'client' ? 'bg-blue-600' :
-              userRole === 'barista' ? 'bg-green-600' : ''
+              userRole === Roles.BARISTA ? 'bg-green-600' : ''
             }
           >
             {userRole || "Sin rol"}
@@ -72,9 +73,9 @@ const AuthDebugPanel: React.FC = () => {
               <span className="text-sm font-medium">Redirección esperada:</span>
             </div>
             <div className="text-sm text-muted-foreground pl-6">
-              {userRole === 'admin' && <span>→ /admin</span>}
+              {userRole === Roles.ADMIN && <span>→ /admin</span>}
               {userRole === 'client' && <span>→ /app</span>}
-              {userRole === 'barista' && <span>→ /recipes</span>}
+              {userRole === Roles.BARISTA && <span>→ /recipes</span>}
             </div>
           </div>
         )}

--- a/src/components/guards/ClientRouteGuard.tsx
+++ b/src/components/guards/ClientRouteGuard.tsx
@@ -2,11 +2,12 @@ import React, { ReactNode } from 'react';
 import { Navigate, useLocation } from 'react-router-dom';
 import { useClientAuth } from '@/hooks/useClientAuth';
 import { ContextualLoading } from '@/components/ui/loading-states';
+import { Roles, Role } from '@/constants/roles';
 
 interface ClientRouteGuardProps {
   children: ReactNode;
   fallback?: ReactNode;
-  requireRole?: string;
+  requireRole?: Role;
 }
 
 /**
@@ -31,7 +32,7 @@ export function ClientRouteGuard({
   }
 
   // Admin users should not access client routes through this guard
-  if (auth.user?.user_metadata?.role === 'admin' || auth.user?.app_metadata?.role === 'admin') {
+  if (auth.user?.user_metadata?.role === Roles.ADMIN || auth.user?.app_metadata?.role === Roles.ADMIN) {
     return <Navigate to="/dashboard" replace />;
   }
 
@@ -41,7 +42,7 @@ export function ClientRouteGuard({
   }
 
   // User doesn't have location access and it's required
-  if (!auth.locationContext && auth.userRole !== 'admin') {
+  if (!auth.locationContext && auth.userRole !== Roles.ADMIN) {
     return <Navigate to="/onboarding/location" replace />;
   }
 

--- a/src/components/guards/TenantRouteGuard.tsx
+++ b/src/components/guards/TenantRouteGuard.tsx
@@ -2,11 +2,12 @@ import React, { ReactNode } from 'react';
 import { Navigate, useParams } from 'react-router-dom';
 import { useOrgAccess, useUserWithRole } from '@/hooks/useUserWithRole';
 import { ContextualLoading } from '@/components/ui/loading-states';
+import { Roles, Role } from '@/constants/roles';
 
 interface TenantRouteGuardProps {
   children: ReactNode;
   fallback?: ReactNode;
-  requiredRole?: 'owner' | 'manager' | 'barista';
+  requiredRole?: Role;
 }
 
 /**
@@ -62,7 +63,7 @@ export function TenantRouteGuard({
  */
 export function OwnerRouteGuard({ children, fallback }: { children: ReactNode; fallback?: ReactNode }) {
   return (
-    <TenantRouteGuard requiredRole="owner" fallback={fallback}>
+    <TenantRouteGuard requiredRole={Roles.OWNER} fallback={fallback}>
       {children}
     </TenantRouteGuard>
   );
@@ -74,7 +75,7 @@ export function OwnerRouteGuard({ children, fallback }: { children: ReactNode; f
 export function StaffRouteGuard({ children, fallback }: { children: ReactNode; fallback?: ReactNode }) {
   const { role } = useUserWithRole();
   
-  if (role !== 'manager' && role !== 'barista') {
+  if (role !== Roles.MANAGER && role !== Roles.BARISTA) {
     return <Navigate to="/dashboard" replace />;
   }
 

--- a/src/components/navigation/AdaptiveSidebar.tsx
+++ b/src/components/navigation/AdaptiveSidebar.tsx
@@ -11,6 +11,7 @@ import {
 import { useLocationContext } from "@/contexts/LocationContext";
 import { useSmartNavigation } from "@/utils/routing/redirects";
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
+import { Roles } from '@/constants/roles';
 import { 
   Collapsible,
   CollapsibleContent,
@@ -65,9 +66,9 @@ export function AdaptiveSidebar() {
   const getRoleIcon = () => {
     if (isAdmin) return <Shield className="h-3 w-3" />;
     switch (userRole?.toLowerCase()) {
-      case 'owner': return <Crown className="h-3 w-3" />;
-      case 'manager': return <Users className="h-3 w-3" />;
-      case 'barista': return <Coffee className="h-3 w-3" />;
+      case Roles.OWNER: return <Crown className="h-3 w-3" />;
+      case Roles.MANAGER: return <Users className="h-3 w-3" />;
+      case Roles.BARISTA: return <Coffee className="h-3 w-3" />;
       default: return <Building className="h-3 w-3" />;
     }
   };
@@ -75,9 +76,9 @@ export function AdaptiveSidebar() {
   const getRoleLabel = () => {
     if (isAdmin) return 'Administrador';
     switch (userRole?.toLowerCase()) {
-      case 'owner': return 'Propietario';
-      case 'manager': return 'Encargado';
-      case 'barista': return 'Barista';
+      case Roles.OWNER: return 'Propietario';
+      case Roles.MANAGER: return 'Encargado';
+      case Roles.BARISTA: return 'Barista';
       case 'client': return 'Cliente';
       default: return 'Usuario';
     }
@@ -135,19 +136,19 @@ export function AdaptiveSidebar() {
       ];
 
       // Add role-specific dashboard views
-      if (userRole?.toLowerCase() === 'owner') {
+      if (userRole?.toLowerCase() === Roles.OWNER) {
         baseItems.push({
           title: "Vista Propietario",
           url: `/tenants/${currentTenantSlug}/dashboard/owner`,
           icon: Crown,
         });
-      } else if (userRole?.toLowerCase() === 'manager') {
+      } else if (userRole?.toLowerCase() === Roles.MANAGER) {
         baseItems.push({
           title: "Vista Encargado",
           url: `/tenants/${currentTenantSlug}/dashboard/manager`,
           icon: Users,
         });
-      } else if (userRole?.toLowerCase() === 'barista') {
+      } else if (userRole?.toLowerCase() === Roles.BARISTA) {
         baseItems.push({
           title: "Vista Barista",
           url: `/tenants/${currentTenantSlug}/dashboard/barista`,
@@ -169,7 +170,7 @@ export function AdaptiveSidebar() {
       ];
 
       // Add management-only items
-      if (['owner', 'manager'].includes(userRole?.toLowerCase() || '')) {
+      if ([Roles.OWNER, Roles.MANAGER].includes(userRole?.toLowerCase() as any)) {
         operationsItems.push(
           {
             title: "Mi Equipo",
@@ -209,7 +210,7 @@ export function AdaptiveSidebar() {
               title: "Academia",
               url: `/tenants/${currentTenantSlug}/academy`,
               icon: GraduationCap,
-              badge: userRole?.toLowerCase() === 'barista' ? "3" : undefined
+              badge: userRole?.toLowerCase() === Roles.BARISTA ? "3" : undefined
             }
           ]
         },

--- a/src/components/navigation/SmartBreadcrumbs.tsx
+++ b/src/components/navigation/SmartBreadcrumbs.tsx
@@ -15,6 +15,7 @@ import {
 } from "lucide-react";
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
 import { useLocationContext } from '@/contexts/LocationContext';
+import { Roles } from '@/constants/roles';
 
 interface BreadcrumbItem {
   label: string;
@@ -168,21 +169,21 @@ export function SmartBreadcrumbs() {
     }
 
     switch (userRole?.toLowerCase()) {
-      case 'owner':
+      case Roles.OWNER:
         return (
           <Badge variant="secondary" className="bg-yellow-100 text-yellow-700">
             <Crown className="h-3 w-3 mr-1" />
             Propietario
           </Badge>
         );
-      case 'manager':
+      case Roles.MANAGER:
         return (
           <Badge variant="secondary" className="bg-blue-100 text-blue-700">
             <Users className="h-3 w-3 mr-1" />
             Encargado
           </Badge>
         );
-      case 'barista':
+      case Roles.BARISTA:
         return (
           <Badge variant="secondary" className="bg-orange-100 text-orange-700">
             <Coffee className="h-3 w-3 mr-1" />

--- a/src/components/onboarding/OnboardingTour.tsx
+++ b/src/components/onboarding/OnboardingTour.tsx
@@ -9,6 +9,7 @@ import {
 } from "lucide-react";
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
 import { useSmartNavigation } from '@/utils/routing/redirects';
+import { Roles } from '@/constants/roles';
 
 interface OnboardingStep {
   id: string;
@@ -68,7 +69,7 @@ export function OnboardingTour({ userRole, isAdmin, onComplete, onDismiss }: Onb
     }
 
     switch (userRole?.toLowerCase()) {
-      case 'owner':
+      case Roles.OWNER:
         return [
           {
             id: 'owner-welcome',
@@ -118,7 +119,7 @@ export function OnboardingTour({ userRole, isAdmin, onComplete, onDismiss }: Onb
           }
         ];
 
-      case 'manager':
+      case Roles.MANAGER:
         return [
           {
             id: 'manager-welcome',
@@ -168,7 +169,7 @@ export function OnboardingTour({ userRole, isAdmin, onComplete, onDismiss }: Onb
           }
         ];
 
-      case 'barista':
+      case Roles.BARISTA:
         return [
           {
             id: 'barista-welcome',

--- a/src/components/routing/SmartRedirectRouter.tsx
+++ b/src/components/routing/SmartRedirectRouter.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Navigate } from 'react-router-dom';
 import { useUserWithRole } from '@/hooks/useUserWithRole';
 import { ContextualLoading } from '@/components/ui/loading-states';
+import { Roles } from '@/constants/roles';
 
 /**
  * Router inteligente que redirige automáticamente al panel correcto
@@ -11,8 +12,7 @@ import { ContextualLoading } from '@/components/ui/loading-states';
 export function SmartRedirectRouter() {
   const { user, isAdmin, orgSlug, role, isLoading } = useUserWithRole();
 
-  // Quick admin check from metadata to avoid waiting for DB
-  const quickAdminCheck = user?.user_metadata?.role === 'admin' || user?.app_metadata?.role === 'admin';
+  const quickAdminCheck = user?.user_metadata?.role === Roles.ADMIN || user?.app_metadata?.role === Roles.ADMIN;
 
   // No authenticated
   if (!user) {
@@ -36,13 +36,13 @@ export function SmartRedirectRouter() {
 
   // Tenant users go to their specific panel based on role
   switch (role) {
-    case 'owner':
+    case Roles.OWNER:
       return <Navigate to={`/org/${orgSlug}/owner/dashboard`} replace />;
-    case 'manager':
+    case Roles.MANAGER:
       return <Navigate to={`/org/${orgSlug}/manager/dashboard`} replace />;
-    case 'barista':
+    case Roles.BARISTA:
       return <Navigate to={`/org/${orgSlug}/staff/dashboard`} replace />;
-    case 'user':
+    case Roles.USER:
     default:
       return <Navigate to={`/org/${orgSlug}/dashboard`} replace />;
   }
@@ -58,9 +58,9 @@ export function UnauthorizedAccess() {
     if (isAdmin) return "/dashboard";
     if (orgSlug) {
       switch (role) {
-        case 'owner': return `/org/${orgSlug}/owner/dashboard`;
-        case 'manager': return `/org/${orgSlug}/manager/dashboard`;
-        case 'barista': return `/org/${orgSlug}/staff/dashboard`;
+        case Roles.OWNER: return `/org/${orgSlug}/owner/dashboard`;
+        case Roles.MANAGER: return `/org/${orgSlug}/manager/dashboard`;
+        case Roles.BARISTA: return `/org/${orgSlug}/staff/dashboard`;
         default: return `/org/${orgSlug}/dashboard`;
       }
     }

--- a/src/constants/adminNavigation.ts
+++ b/src/constants/adminNavigation.ts
@@ -9,6 +9,7 @@ import {
   Calendar, FileText, AlertTriangle, Activity, Home
 } from "lucide-react";
 import { LucideIcon } from "lucide-react";
+import { Roles } from './roles';
 
 export interface AdminNavItem {
   title: string;
@@ -192,7 +193,7 @@ export const ADMIN_NAVIGATION: Record<string, AdminNavGroup> = {
   SYSTEM: {
     title: 'System',
     description: 'Configuración y administración del sistema',
-    roles: ['admin'],
+    roles: [Roles.ADMIN],
     items: [
       {
         title: 'Settings',

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -1,0 +1,13 @@
+export const Roles = {
+  ADMIN: 'admin',
+  OWNER: 'owner',
+  MANAGER: 'manager',
+  BARISTA: 'barista',
+  USER: 'user'
+} as const;
+
+export type Role = typeof Roles[keyof typeof Roles];
+
+export function isRole(value: unknown): value is Role {
+  return typeof value === 'string' && (Object.values(Roles) as string[]).includes(value);
+}

--- a/src/constants/routes.ts
+++ b/src/constants/routes.ts
@@ -1,3 +1,5 @@
+import { Roles, Role } from './roles';
+
 /**
  * Centralized route constants for type-safe navigation
  * Organized by functional domain with consistent naming conventions
@@ -99,22 +101,15 @@ export const LEGACY_ROUTES = {
 } as const;
 
 // ===== ROLE DEFINITIONS =====
-export const USER_ROLES = {
-  ADMIN: 'admin',
-  OWNER: 'owner',
-  MANAGER: 'manager',
-  BARISTA: 'barista',
-  USER: 'user',
-} as const;
+export const USER_ROLES = Roles;
 
 // ===== ROLE PERMISSIONS =====
 export const ROUTE_PERMISSIONS = {
   PUBLIC: [],
-  ALL_AUTHENTICATED: [USER_ROLES.ADMIN, USER_ROLES.OWNER, USER_ROLES.MANAGER, USER_ROLES.BARISTA, USER_ROLES.USER],
-  MANAGEMENT: [USER_ROLES.ADMIN, USER_ROLES.OWNER, USER_ROLES.MANAGER],
-  ADMIN_ONLY: [USER_ROLES.ADMIN],
-  OWNER_ONLY: [USER_ROLES.ADMIN, USER_ROLES.OWNER],
+  ALL_AUTHENTICATED: [Roles.ADMIN, Roles.OWNER, Roles.MANAGER, Roles.BARISTA, Roles.USER],
+  MANAGEMENT: [Roles.ADMIN, Roles.OWNER, Roles.MANAGER],
+  ADMIN_ONLY: [Roles.ADMIN],
+  OWNER_ONLY: [Roles.ADMIN, Roles.OWNER],
 } as const;
-
-export type UserRole = typeof USER_ROLES[keyof typeof USER_ROLES];
+export type UserRole = Role;
 export type RoutePermission = typeof ROUTE_PERMISSIONS[keyof typeof ROUTE_PERMISSIONS];

--- a/src/hooks/useAdminAuth.ts
+++ b/src/hooks/useAdminAuth.ts
@@ -2,6 +2,7 @@ import { useAuth } from '@/contexts/OptimizedAuthProvider';
 import { useCallback, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { AuthMiddleware } from '@/middleware/authMiddleware';
+import { Roles } from '@/constants/roles';
 
 export interface AdminAuthResult {
   user: any;
@@ -34,7 +35,7 @@ export function useAdminAuth(): AdminAuthResult {
   // Admin-specific validation
   useEffect(() => {
     if (!auth.loading && auth.isInitialized) {
-      const quickAdminCheck = auth.user?.user_metadata?.role === 'admin' || auth.user?.app_metadata?.role === 'admin';
+      const quickAdminCheck = auth.user?.user_metadata?.role === Roles.ADMIN || auth.user?.app_metadata?.role === Roles.ADMIN;
 
       if (auth.user && !auth.isAdmin && !quickAdminCheck) {
         // Non-admin users should go to client app

--- a/src/hooks/useAuthFlowValidator.ts
+++ b/src/hooks/useAuthFlowValidator.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useOptimizedAuth } from '@/contexts/OptimizedAuthProvider';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from '@/hooks/use-toast';
+import { Roles } from '@/constants/roles';
 
 interface AuthFlowTestResult {
   test: string;
@@ -110,7 +111,7 @@ export function useAuthFlowValidator() {
         };
       }
 
-      const validRoles = ['admin', 'client', 'barista'];
+      const validRoles = [Roles.ADMIN, 'client', Roles.BARISTA];
       if (!validRoles.includes(userRole.toLowerCase())) {
         return {
           test: 'Role Assignment',

--- a/src/hooks/useClientAuth.ts
+++ b/src/hooks/useClientAuth.ts
@@ -2,6 +2,7 @@ import { useAuth } from '@/contexts/OptimizedAuthProvider';
 import { useCallback, useEffect } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { AuthMiddleware } from '@/middleware/authMiddleware';
+import { Roles } from '@/constants/roles';
 
 export interface ClientAuthResult {
   user: any;
@@ -45,7 +46,7 @@ export function useClientAuth(): ClientAuthResult {
         auth.user,
         auth.session,
         location.pathname,
-        { requireAuth: true, tenantOnly: true, allowedRoles: ['owner', 'manager', 'barista', 'user'] }
+        { requireAuth: true, tenantOnly: true, allowedRoles: [Roles.OWNER, Roles.MANAGER, Roles.BARISTA, Roles.USER] }
       ).then(validation => {
         if (validation.redirectTo && validation.redirectTo !== location.pathname) {
           navigate(validation.redirectTo, { replace: true });

--- a/src/hooks/useEnhancedAuth.ts
+++ b/src/hooks/useEnhancedAuth.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react';
 import { useOptimizedAuth } from '@/contexts/OptimizedAuthProvider';
 import { useLocationContext } from '@/contexts/LocationContext';
 import { TestingMode } from '@/lib/config';
+import { Roles } from '@/constants/roles';
 
 export interface EnhancedAuthState {
   // Auth state
@@ -32,11 +33,11 @@ export interface EnhancedAuthState {
 // Role hierarchy for comparison
 const ROLE_HIERARCHY = {
   'client': 1,
-  'barista': 2,
-  'manager': 3,
-  'owner': 4,
-  'admin': 5
-};
+  [Roles.BARISTA]: 2,
+  [Roles.MANAGER]: 3,
+  [Roles.OWNER]: 4,
+  [Roles.ADMIN]: 5
+} as const;
 
 /**
  * Enhanced auth hook with intelligent role checking and context awareness

--- a/src/hooks/useLocationPreloader.ts
+++ b/src/hooks/useLocationPreloader.ts
@@ -2,6 +2,7 @@ import { useEffect, useCallback } from 'react';
 import { useEnhancedAuth } from './useEnhancedAuth';
 import { useLocationContext } from '@/contexts/LocationContext';
 import { supabase } from '@/integrations/supabase/client';
+import { Roles } from '@/constants/roles';
 
 interface LocationCacheEntry {
   data: any;
@@ -64,7 +65,7 @@ export function useLocationPreloader() {
     }
 
     // Skip preloading for admin users or if we already have an active location
-    if (userRole === 'admin' || activeLocation) return;
+    if (userRole === Roles.ADMIN || activeLocation) return;
 
     try {
       console.info('🔄 LocationPreloader: Preloading user location...', { userRole });
@@ -114,16 +115,16 @@ export function useLocationPreloader() {
 
       switch (userRole.toLowerCase()) {
         case 'client':
-        case 'manager':
-        case 'owner':
+        case Roles.MANAGER:
+        case Roles.OWNER:
           routesToPreload.push('/dashboard', '/app/consumo', '/app/recetas');
           break;
-      case 'barista':
-        routesToPreload.push('/recipes', '/app/academia');
-        break;
-      case 'admin':
-        routesToPreload.push('/admin/dashboard', '/admin/operations');
-        break;
+        case Roles.BARISTA:
+          routesToPreload.push('/recipes', '/app/academia');
+          break;
+        case Roles.ADMIN:
+          routesToPreload.push('/admin/dashboard', '/admin/operations');
+          break;
     }
 
     // Preload routes using link prefetch (browser native)

--- a/src/hooks/useRequireAdmin.ts
+++ b/src/hooks/useRequireAdmin.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useAuth } from '@/contexts/OptimizedAuthProvider';
 import { useNavigate } from 'react-router-dom';
+import { Roles } from '@/constants/roles';
 
 export function useRequireAdmin() {
   const { user, loading, isInitialized } = useAuth();
@@ -15,7 +16,7 @@ export function useRequireAdmin() {
 
       // Check if user has admin role
       const userRole = user.user_metadata?.role || user.app_metadata?.role;
-      if (userRole !== 'admin') {
+      if (userRole !== Roles.ADMIN) {
         navigate('/dashboard');
         return;
       }
@@ -25,6 +26,6 @@ export function useRequireAdmin() {
   return {
     user,
     loading,
-    isAdmin: user?.user_metadata?.role === 'admin' || user?.app_metadata?.role === 'admin'
+    isAdmin: user?.user_metadata?.role === Roles.ADMIN || user?.app_metadata?.role === Roles.ADMIN
   };
 }

--- a/src/middleware/authMiddleware.ts
+++ b/src/middleware/authMiddleware.ts
@@ -2,18 +2,19 @@ import React from 'react';
 import { User, Session } from '@supabase/supabase-js';
 import { supabase } from '@/integrations/supabase/client';
 import { getUserRole } from '@/utils/authRoleUtils';
+import { Roles, Role } from '@/constants/roles';
 
 export interface AuthValidationResult {
   isValid: boolean;
   redirectTo?: string;
   reason?: string;
-  userRole?: string;
+  userRole?: Role | null;
   orgId?: string;
 }
 
 export interface RouteProtection {
   requireAuth?: boolean;
-  allowedRoles?: string[];
+  allowedRoles?: Role[];
   requireOrgAccess?: boolean;
   adminOnly?: boolean;
   tenantOnly?: boolean;
@@ -63,9 +64,9 @@ export class AuthMiddleware {
     // If accessing admin routes and user is admin, bypass org/location checks
     if (isAdminRoute && roleResult?.isAdmin) {
       if (routePath.startsWith('/admin/login')) {
-        return { isValid: true, redirectTo: '/admin/dashboard', userRole: 'admin' };
+        return { isValid: true, redirectTo: '/admin/dashboard', userRole: Roles.ADMIN };
       }
-      return { isValid: true, userRole: 'admin' };
+      return { isValid: true, userRole: Roles.ADMIN };
     }
 
     // For non-admins or non-admin routes, fetch user context
@@ -183,7 +184,7 @@ export class AuthMiddleware {
    * Obtiene la ruta por defecto según el rol del usuario
    */
   private static getDefaultRouteForRole(role: string, orgId: string, userContext: any): string {
-    if (role === 'admin') {
+    if (role === Roles.ADMIN) {
       return '/admin/dashboard';
     }
 
@@ -194,10 +195,10 @@ export class AuthMiddleware {
     const orgSlug = this.getOrgSlug(userContext);
 
     switch (role) {
-      case 'owner':
+      case Roles.OWNER:
         return `/org/${orgSlug}/owner/dashboard`;
-      case 'manager':
-      case 'barista':
+      case Roles.MANAGER:
+      case Roles.BARISTA:
         return `/org/${orgSlug}/staff/dashboard`;
       default:
         return `/org/${orgSlug}/dashboard`;

--- a/src/pages/AdminLoginPage.tsx
+++ b/src/pages/AdminLoginPage.tsx
@@ -11,6 +11,7 @@ import { Mail, Lock, Shield, AlertCircle, RefreshCw } from 'lucide-react';
 import { useState, useEffect } from 'react';
 import { supabase } from '@/integrations/supabase/client';
 import { useToast } from '@/hooks/use-toast';
+import { Roles } from '@/constants/roles';
 
 export function AdminLoginPage() {
   const auth = useAuth();
@@ -38,7 +39,7 @@ export function AdminLoginPage() {
         .from('user_roles')
         .select('role')
         .eq('user_id', auth.user.id)
-        .eq('role', 'admin')
+        .eq('role', Roles.ADMIN)
         .single();
 
       if (error || !data) {

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,6 +13,7 @@ import { Coffee, TrendingUp, Users, BookOpen, MapPin, Building, GraduationCap, P
 import { useLocationContext } from "@/contexts/LocationContext";
 import { useSmartNavigation } from "@/utils/routing/redirects";
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
+import { Roles } from '@/constants/roles';
 
 export default function Dashboard() {
   const location = useLocation();
@@ -88,14 +89,14 @@ export default function Dashboard() {
         {isInTenantContext && dashboardRole !== 'overview' && (
           <div className="bg-muted/50 rounded-lg p-4">
             <h2 className="font-semibold text-sm mb-2">
-              {dashboardRole === 'owner' && 'Vista de Propietario'}
-              {dashboardRole === 'manager' && 'Vista de Encargado'}
-              {dashboardRole === 'barista' && 'Vista de Barista'}
+              {dashboardRole === Roles.OWNER && 'Vista de Propietario'}
+              {dashboardRole === Roles.MANAGER && 'Vista de Encargado'}
+              {dashboardRole === Roles.BARISTA && 'Vista de Barista'}
             </h2>
             <p className="text-sm text-muted-foreground">
-              {dashboardRole === 'owner' && 'Acceso completo a todas las funciones y reportes del negocio.'}
-              {dashboardRole === 'manager' && 'Gestión operativa, personal y reportes de rendimiento.'}
-              {dashboardRole === 'barista' && 'Herramientas para el día a día: recetas, academia y recursos.'}
+              {dashboardRole === Roles.OWNER && 'Acceso completo a todas las funciones y reportes del negocio.'}
+              {dashboardRole === Roles.MANAGER && 'Gestión operativa, personal y reportes de rendimiento.'}
+              {dashboardRole === Roles.BARISTA && 'Herramientas para el día a día: recetas, academia y recursos.'}
             </p>
           </div>
         )}

--- a/src/pages/OnboardingPage.tsx
+++ b/src/pages/OnboardingPage.tsx
@@ -4,13 +4,14 @@ import { Navigate } from 'react-router-dom';
 import { useUserWithRole } from '@/hooks/useUserWithRole';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Coffee, Shield, Users, TrendingUp } from 'lucide-react';
+import { Roles } from '@/constants/roles';
 import { ContextualLoading } from '@/components/ui/loading-states';
 
 export function OnboardingPage() {
   const { user, orgId, isLoading, isAdmin } = useUserWithRole();
 
   // Loading state - but check for admin from metadata first
-  const quickAdminCheck = user?.user_metadata?.role === 'admin' || user?.app_metadata?.role === 'admin';
+  const quickAdminCheck = user?.user_metadata?.role === Roles.ADMIN || user?.app_metadata?.role === Roles.ADMIN;
   
   // If we can quickly determine it's an admin, redirect immediately
   if (quickAdminCheck && !isLoading) {

--- a/src/pages/ProfilePage.tsx
+++ b/src/pages/ProfilePage.tsx
@@ -9,6 +9,7 @@ import { Badge } from '@/components/ui/badge';
 import { Separator } from '@/components/ui/separator';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { useLocationContext } from '@/contexts/LocationContext';
+import { Roles } from '@/constants/roles';
 
 export function ProfilePage() {
   const { user, userRole, session } = useOptimizedAuth();
@@ -37,11 +38,11 @@ export function ProfilePage() {
 
   const getRoleBadgeColor = (role: string | null) => {
     switch (role) {
-      case 'admin':
+      case Roles.ADMIN:
         return 'bg-destructive text-destructive-foreground';
       case 'client':
         return 'bg-primary text-primary-foreground';
-      case 'barista':
+      case Roles.BARISTA:
         return 'bg-secondary text-secondary-foreground';
       default:
         return 'bg-muted text-muted-foreground';
@@ -239,7 +240,7 @@ export function ProfilePage() {
               
               <div className="text-center p-4 bg-muted/50 rounded-lg">
                 <div className="text-2xl font-bold text-primary">
-                  {userRole === 'admin' ? 'Admin' : 'Usuario'}
+                  {userRole === Roles.ADMIN ? 'Admin' : 'Usuario'}
                 </div>
                 <div className="text-sm text-muted-foreground">Nivel de acceso</div>
               </div>

--- a/src/utils/authMiddleware.ts
+++ b/src/utils/authMiddleware.ts
@@ -1,5 +1,6 @@
 import { User, Session } from '@supabase/supabase-js';
-import { getUserRole, getUserLocationContext, UserRole, RoleCheckResult } from './authRoleUtils';
+import { getUserRole, getUserLocationContext, RoleCheckResult } from './authRoleUtils';
+import { Roles, Role } from '@/constants/roles';
 
 export interface AuthValidationResult {
   isValid: boolean;
@@ -12,7 +13,7 @@ export interface AuthValidationResult {
 export interface RedirectOptions {
   forceAdmin?: boolean;
   requireLocation?: boolean;
-  allowedRoles?: UserRole[];
+  allowedRoles?: Role[];
   fallbackRoute?: string;
 }
 
@@ -39,7 +40,7 @@ export async function validateAndRedirectUser(
   
   // Get location context if required
   let locationContext = null;
-  if (options.requireLocation || userRole.role !== 'admin') {
+  if (options.requireLocation || userRole.role !== Roles.ADMIN) {
     locationContext = await getUserLocationContext(user.id);
   }
 
@@ -55,8 +56,8 @@ export async function validateAndRedirectUser(
 
   // Role-based validation
   if (options.allowedRoles && options.allowedRoles.length > 0) {
-    const hasRequiredRole = options.allowedRoles.some(role => 
-      userRole.role === role || (userRole.isAdmin && role !== 'admin')
+    const hasRequiredRole = options.allowedRoles.some(role =>
+      userRole.role === role || (userRole.isAdmin && role !== Roles.ADMIN)
     );
     
     if (!hasRequiredRole) {
@@ -94,12 +95,9 @@ export async function validateAndRedirectUser(
  * Determine login route based on current path and options
  */
 function determineLoginRoute(currentPath: string, options: RedirectOptions): string {
-  // Admin routes should go to admin login
   if (currentPath.startsWith('/admin') || options.forceAdmin) {
     return '/admin/login';
   }
-  
-  // Default client login
   return '/login';
 }
 

--- a/src/utils/authQueries.ts
+++ b/src/utils/authQueries.ts
@@ -1,5 +1,6 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
+import { Roles } from '@/constants/roles';
 
 export interface UserRoleData {
   role: string | null;
@@ -25,7 +26,7 @@ export async function getUserRoleAndAdmin(userId: string): Promise<UserRoleData>
 
     // Extract role from user_metadata
     const role = user.user_metadata?.role || null;
-    const isAdmin = role === 'admin';
+    const isAdmin = role === Roles.ADMIN;
     
     console.info('✅ AuthQuery: Role from metadata:', { role, isAdmin, userId, metadata: user.user_metadata });
     return { role, isAdmin, userId };

--- a/src/utils/routing/guards.tsx
+++ b/src/utils/routing/guards.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
 import { ROUTE_PERMISSIONS, UserRole } from '@/constants/routes';
+import { Roles } from '@/constants/roles';
 import { ContextualLoading } from '@/components/ui/loading-states';
 import { ErrorState, RoleBasedError } from '@/components/ui/error-states';
 import { TestingMode } from '@/lib/config';
@@ -95,7 +96,7 @@ export function RoleGuard({
   // Check if user has any of the required roles (or testing mode is enabled)
   const hasAccess = TestingMode.enabled || hasAnyRole(roleStrings) || 
     // Allow 'user' role for basic access to authenticated routes
-    (roleStrings.includes('user') && ['client', 'barista', 'manager', 'owner'].includes(userRole?.toLowerCase() || ''));
+    (roleStrings.includes(Roles.USER) && ['client', Roles.BARISTA, Roles.MANAGER, Roles.OWNER].includes(userRole?.toLowerCase() || ''));
 
   if (!hasAccess) {
     return fallback || (
@@ -105,12 +106,12 @@ export function RoleGuard({
         onNavigateBack={() => {
           // Smart navigation based on user role
           switch (userRole?.toLowerCase()) {
-            case 'barista':
+            case Roles.BARISTA:
               navigate('/recipes');
               break;
             case 'client':
-            case 'manager':
-            case 'owner':
+            case Roles.MANAGER:
+            case Roles.OWNER:
               navigate('/dashboard');
               break;
             default:

--- a/src/utils/routing/redirects.tsx
+++ b/src/utils/routing/redirects.tsx
@@ -3,6 +3,7 @@ import { useNavigate, useParams, useLocation } from 'react-router-dom';
 import { useLocationContext } from '@/contexts/LocationContext';
 import { useEnhancedAuth } from '@/hooks/useEnhancedAuth';
 import { buildTenantRoute, buildPublicRoute } from './helpers';
+import { Roles } from '@/constants/roles';
 
 /**
  * Legacy Route Redirector
@@ -101,21 +102,21 @@ export function useSmartNavigation() {
     navigate(targetPath);
   }, [activeLocation?.slug, userRole, navigate]);
 
-  const navigateToRole = useCallback((role: 'owner' | 'manager' | 'barista' | 'overview' = 'overview') => {
+  const navigateToRole = useCallback((role: Roles | 'overview' = 'overview') => {
     if (!activeLocation?.slug) {
       console.warn('No active location for role navigation, using fallback');
       
       // Intelligent fallback based on user role
       switch (userRole?.toLowerCase()) {
-        case 'admin':
+        case Roles.ADMIN:
           navigate('/admin/dashboard');
           return;
-        case 'barista':
+        case Roles.BARISTA:
           navigate('/recipes');
           return;
         case 'client':
-        case 'manager':
-        case 'owner':
+        case Roles.MANAGER:
+        case Roles.OWNER:
         default:
           navigate('/app');
           return;
@@ -124,10 +125,10 @@ export function useSmartNavigation() {
     
     const routes = {
       overview: buildTenantRoute.dashboard.overview,
-      owner: buildTenantRoute.dashboard.owner,
-      manager: buildTenantRoute.dashboard.manager,
-      barista: buildTenantRoute.dashboard.barista,
-    };
+      [Roles.OWNER]: buildTenantRoute.dashboard.owner,
+      [Roles.MANAGER]: buildTenantRoute.dashboard.manager,
+      [Roles.BARISTA]: buildTenantRoute.dashboard.barista,
+    } as const;
     
     const targetPath = routes[role]({ locationSlug: activeLocation.slug });
     console.info('🔄 SmartNavigation: Role-based navigation', { 
@@ -170,22 +171,22 @@ export function useSmartNavigation() {
     }
 
     // Only go to admin dashboard if explicitly admin role
-    if (isAdmin && userRole?.toLowerCase() === 'admin') {
+    if (isAdmin && userRole?.toLowerCase() === Roles.ADMIN) {
       navigate('/admin/dashboard');
       return;
     }
 
     // Default fallback prioritizes client routes
     switch (userRole?.toLowerCase()) {
-      case 'barista':
+      case Roles.BARISTA:
         navigate('/recipes');
         break;
-      case 'admin':
+      case Roles.ADMIN:
         navigate('/admin/dashboard');
         break;
       case 'client':
-      case 'manager':
-      case 'owner':
+      case Roles.MANAGER:
+      case Roles.OWNER:
       default:
         navigate('/app');
         break;


### PR DESCRIPTION
## Summary
- add centralized `Roles` constants with `isRole` type guard
- refactor auth utilities, middleware, and components to use `Roles`
- cover new `Roles` enum with unit tests

## Testing
- `npx vitest run` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vitest)*

------
https://chatgpt.com/codex/tasks/task_e_6896aaa9b140832dadafc72c3982b2f5