### PR TITLE
Allow iframe embedding and add login test

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,7 +40,7 @@ Una vez completado el deployment exitoso, **DEBE** reemplazarse por una CSP estr
   object-src 'none';
   base-uri 'self';
   form-action 'self';
-  frame-ancestors 'none';
+  frame-ancestors 'self' https://partner.example.com;
 ">
 ```
 
@@ -48,10 +48,19 @@ Una vez completado el deployment exitoso, **DEBE** reemplazarse por una CSP estr
 
 ### Implementados ✅
 - `X-Content-Type-Options: nosniff`
-- `X-Frame-Options: DENY`
+- `X-Frame-Options: ALLOW-FROM https://partner.example.com`
 - `X-XSS-Protection: 1; mode=block`
 - `Referrer-Policy: strict-origin-when-cross-origin`
 - `Permissions-Policy: camera=(), microphone=(), geolocation=(), payment=()`
+
+## Embebido en Iframes
+
+### Casos de uso permitidos
+- Portal de socios en `https://partner.example.com`
+
+### Riesgos y mitigaciones
+- **Clickjacking**: mitigado mediante `frame-ancestors` limitando dominios autorizados.
+- **Ataques de inyección**: validar origen del iframe antes de autenticar.
 
 ## Autenticación y Autorización
 

--- a/cypress/e2e/iframe-login.cy.ts
+++ b/cypress/e2e/iframe-login.cy.ts
@@ -1,0 +1,11 @@
+/// <reference types="cypress" />
+
+describe('Login dentro de iframe autorizado', () => {
+  it('renderiza la página de login dentro del iframe', () => {
+    cy.visit('/iframe-auth-test.html');
+    cy.get('#app-frame').then(($iframe) => {
+      const $body = $iframe.contents().find('body');
+      cy.wrap($body).contains('login', { matchCase: false });
+    });
+  });
+});

--- a/docs/IFRAME_EMBEDDING.md
+++ b/docs/IFRAME_EMBEDDING.md
@@ -1,0 +1,23 @@
+# Embebido de la Aplicación en Iframes
+
+Este documento describe los casos de uso autorizados, riesgos y procedimientos de prueba para embebido de la aplicación dentro de iframes.
+
+## Casos de Uso Permitidos
+- Integración en el portal de socios `https://partner.example.com` para login centralizado.
+
+## Riesgos de Seguridad
+- **Clickjacking:** mitigado mediante `frame-ancestors` y validación de origen.
+- **Exposición de sesión:** asegurarse de usar HTTPS y controles de origen en el host.
+
+## Pruebas Manuales
+1. Servir la aplicación en `http://localhost:8080`.
+2. Crear una página contenedora en `https://partner.example.com` con un iframe que apunte a la aplicación.
+3. Verificar que la página de login se renderice dentro del iframe y que el flujo de autenticación complete correctamente.
+4. Repetir el proceso desde un dominio no autorizado y confirmar que el navegador bloquea la carga.
+
+## Pruebas Automatizadas
+Se añadió un test de Cypress que verifica que la página de login puede cargarse dentro de un iframe autorizado.
+
+```bash
+npx cypress run --spec cypress/e2e/iframe-login.cy.ts
+```

--- a/public/iframe-auth-test.html
+++ b/public/iframe-auth-test.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Iframe Auth Test</title>
+</head>
+<body>
+  <iframe id="app-frame" src="/" width="800" height="600"></iframe>
+</body>
+</html>

--- a/vercel.json
+++ b/vercel.json
@@ -5,9 +5,9 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co wss://*.supabase.in; frame-src 'none'; object-src 'none'; base-uri 'self'; form-action 'self'"
+          "value": "default-src 'self'; script-src 'self' https://*.supabase.co; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self'; connect-src 'self' https://*.supabase.co https://*.supabase.in wss://*.supabase.co wss://*.supabase.in; frame-src 'none'; frame-ancestors 'self' https://partner.example.com; object-src 'none'; base-uri 'self'; form-action 'self'"
         },
-        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "X-Frame-Options", "value": "ALLOW-FROM https://partner.example.com" },
         { 
           "key": "Strict-Transport-Security", 
           "value": "max-age=63072000; includeSubDomains; preload" 


### PR DESCRIPTION
## Summary
- permit embedding from partner portal via CSP `frame-ancestors`
- document iframe risks and allowed use cases
- add Cypress test and example page for iframe login

## Testing
- `npx cypress run --spec cypress/e2e/iframe-login.cy.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/cypress)*
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6896aa97db18832dbdbe964ad00b2ea1