### PR TITLE
feat: redirect to profile after login

### DIFF
--- a/src/pages/LoginPage.tsx
+++ b/src/pages/LoginPage.tsx
@@ -13,6 +13,7 @@ import { supabase } from '@/integrations/supabase/client';
 import { useToastNotifications } from '@/hooks/use-toast-notifications';
 import { useToast } from '@/hooks/use-toast';
 import { useOptimizedAuth } from '@/contexts/OptimizedAuthProvider';
+import { useUserRedirectUrl } from '@/hooks/useUserWithRole';
 import { useNavigate } from 'react-router-dom';
 
 interface LoginPageProps {
@@ -31,6 +32,7 @@ export default function LoginPage({ onLoginSuccess }: LoginPageProps) {
   const { toast } = useToast();
   const { signInWithEmail, signInWithGoogle, loading: authLoading, error: authError, clearError } = useOptimizedAuth();
   const navigate = useNavigate();
+  const profileUrl = useUserRedirectUrl();
   
   // Rate limiting hook
   const { 
@@ -152,6 +154,9 @@ export default function LoginPage({ onLoginSuccess }: LoginPageProps) {
         title: "Login exitoso",
         description: "Bienvenido a TUPÁ Hub",
       });
+      if (profileUrl) {
+        navigate(profileUrl, { replace: true });
+      }
     } else {
       console.error('Auth error:', result.error);
       
@@ -212,6 +217,9 @@ export default function LoginPage({ onLoginSuccess }: LoginPageProps) {
         title: "Login exitoso",
         description: "Bienvenido a TUPÁ Hub",
       });
+      if (profileUrl) {
+        navigate(profileUrl, { replace: true });
+      }
     } catch (error: any) {
       console.error('Google login error:', error);
       


### PR DESCRIPTION
## Summary
- redirect to role-aware profile URL after successful email or Google login
- test login redirection to ensure users are routed off the login page

## Testing
- `npx vitest run src/__tests__/pages/LoginPage.test.tsx` *(fails: 403 Forbidden fetching vitest package)*

------
https://chatgpt.com/codex/tasks/task_e_6896c5f04f18832dab78c1f93e410d53