### PR TITLE
fix: redirect Google OAuth to app dashboard

### DIFF
--- a/src/hooks/useOptimizedAuth.ts
+++ b/src/hooks/useOptimizedAuth.ts
@@ -149,7 +149,7 @@ export function useOptimizedAuth() {
       const { error } = await supabase.auth.signInWithOAuth({
         provider: 'google',
         options: {
-          redirectTo: `${window.location.origin}/`
+          redirectTo: `${window.location.origin}/app`
         }
       });
 


### PR DESCRIPTION
## Summary
- redirect Supabase Google OAuth to /app after sign-in

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_689d5822a024832dac55b4077c2cdfc3