### PR TITLE
Redirect login to dashboard

### DIFF
--- a/src/pages/FriendlyLoginPage.tsx
+++ b/src/pages/FriendlyLoginPage.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState, useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Navigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -30,6 +30,10 @@ export default function FriendlyLoginPage() {
     clearError,
     isAuthenticated
   } = useAuth();
+
+  if (isAuthenticated && user) {
+    return <Navigate to="/app" replace />;
+  }
 
   // Create simple loading states for compatibility
   const authProgress = loading ? 75 : 0;


### PR DESCRIPTION
## Summary
- Send authenticated users directly to `/app` from the friendly login page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_689d42ffa990832d89fa5961d7a19a0f